### PR TITLE
CommitLog struct

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -391,6 +391,8 @@ dependencies = [
  "parking_lot",
  "rb_tree",
  "ring",
+ "rmp",
+ "rmp-serde",
  "rustls-pemfile",
  "serde",
  "serde_json",
@@ -554,6 +556,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c520e05135d6e763148b6426a837e239041653ba7becd2e538c076c738025fc"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -635,6 +643,28 @@ dependencies = [
  "untrusted",
  "web-sys",
  "winapi",
+]
+
+[[package]]
+name = "rmp"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44519172358fd6d58656c86ab8e7fbc9e1490c3e8f14d35ed78ca0dd07403c9f"
+dependencies = [
+ "byteorder",
+ "num-traits",
+ "paste",
+]
+
+[[package]]
+name = "rmp-serde"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25786b0d276110195fa3d6f3f31299900cf71dfbd6c28450f3f58a0e7f7a347e"
+dependencies = [
+ "byteorder",
+ "rmp",
+ "serde",
 ]
 
 [[package]]
@@ -965,6 +995,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cfcd319456c4d6ea10087ed423473267e1a071f3bc0aa89f80d60997843c6f0"
 dependencies = [
  "getrandom",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,6 +52,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bit-vec"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -397,6 +406,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "base64",
+ "bincode",
  "bloom-filter-rs",
  "cached",
  "chrono",
@@ -407,8 +417,6 @@ dependencies = [
  "parking_lot",
  "rb_tree",
  "ring",
- "rmp",
- "rmp-serde",
  "rustls-pemfile",
  "serde",
  "serde_json",
@@ -572,12 +580,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c520e05135d6e763148b6426a837e239041653ba7becd2e538c076c738025fc"
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -659,28 +661,6 @@ dependencies = [
  "untrusted",
  "web-sys",
  "winapi",
-]
-
-[[package]]
-name = "rmp"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44519172358fd6d58656c86ab8e7fbc9e1490c3e8f14d35ed78ca0dd07403c9f"
-dependencies = [
- "byteorder",
- "num-traits",
- "paste",
-]
-
-[[package]]
-name = "rmp-serde"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25786b0d276110195fa3d6f3f31299900cf71dfbd6c28450f3f58a0e7f7a347e"
-dependencies = [
- "byteorder",
- "rmp",
- "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -219,6 +219,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 
 [[package]]
+name = "either"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -362,6 +368,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -387,6 +402,7 @@ dependencies = [
  "chrono",
  "clap",
  "dotenv",
+ "itertools",
  "lazy_static",
  "parking_lot",
  "rb_tree",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ lazy_static = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "ansi", "fmt", "std", "json"] }
 # https://docs.rs/uuid/latest/uuid/
-uuid = { version = "1", features = ["v4"] }
+uuid = { version = "1", features = ["v4", "serde"] }
 # date / time
 # https://docs.rs/chrono/latest/chrono/
 chrono = "0.4"
@@ -62,3 +62,7 @@ rb_tree = "0.5.0"
 # bloom filter implementation
 # https://docs.rs/bloom-filter-rs/0.1.0/bloom_filter_rs/
 bloom-filter-rs = "0.1.0"
+# An efficient ser/de format
+# https://docs.rs/rmp/latest/rmp/
+rmp = "0.8.11"
+rmp-serde = "1.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,3 +66,6 @@ bloom-filter-rs = "0.1.0"
 # https://docs.rs/rmp/latest/rmp/
 rmp = "0.8.11"
 rmp-serde = "1.1.0"
+# utilties for iterables
+# https://docs.rs/itertools/0.10.3
+itertools = "0.10.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,9 +63,8 @@ rb_tree = "0.5.0"
 # https://docs.rs/bloom-filter-rs/0.1.0/bloom_filter_rs/
 bloom-filter-rs = "0.1.0"
 # An efficient ser/de format
-# https://docs.rs/rmp/latest/rmp/
-rmp = "0.8.11"
-rmp-serde = "1.1.0"
+# https://docs.rs/bincode/latest/bincode/
+bincode = "1.3.3"
 # utilties for iterables
 # https://docs.rs/itertools/0.10.3
 itertools = "0.10.3"

--- a/src/error.rs
+++ b/src/error.rs
@@ -8,6 +8,9 @@ pub enum Error {
 
     #[error("parseint error: {0}")]
     ParseIntError(#[from] std::num::ParseIntError),
+
+    #[error("messagepack decode error: {0}")]
+    MsgPackDecode(#[from] rmp_serde::decode::Error)
 }
 impl From<&str> for Error {
     fn from(s: &str) -> Error {

--- a/src/error.rs
+++ b/src/error.rs
@@ -10,7 +10,10 @@ pub enum Error {
     ParseIntError(#[from] std::num::ParseIntError),
 
     #[error("messagepack decode error: {0}")]
-    MsgPackDecode(#[from] rmp_serde::decode::Error)
+    MsgPackDecode(#[from] rmp_serde::decode::Error),
+
+    #[error("uuid error: {0}")]
+    UuidError(#[from] uuid::Error),
 }
 impl From<&str> for Error {
     fn from(s: &str) -> Error {

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,9 +9,6 @@ pub enum Error {
     #[error("parseint error: {0}")]
     ParseIntError(#[from] std::num::ParseIntError),
 
-    #[error("uuid error: {0}")]
-    UuidError(#[from] uuid::Error),
-
     #[error("bincode error: {0}")]
     BincodeError(#[from] bincode::Error),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -14,9 +14,6 @@ pub enum Error {
 
     #[error("bincode error: {0}")]
     BincodeError(#[from] bincode::Error),
-
-    #[error("system time error: {0}")]
-    SystemTimeError(#[from] std::time::SystemTimeError),
 }
 impl From<&str> for Error {
     fn from(s: &str) -> Error {

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,11 +9,14 @@ pub enum Error {
     #[error("parseint error: {0}")]
     ParseIntError(#[from] std::num::ParseIntError),
 
-    #[error("messagepack decode error: {0}")]
-    MsgPackDecode(#[from] rmp_serde::decode::Error),
-
     #[error("uuid error: {0}")]
     UuidError(#[from] uuid::Error),
+
+    #[error("bincode error: {0}")]
+    BincodeError(#[from] bincode::Error),
+
+    #[error("system time error: {0}")]
+    SystemTimeError(#[from] std::time::SystemTimeError),
 }
 impl From<&str> for Error {
     fn from(s: &str) -> Error {

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,7 +1,6 @@
 use crate::error::Result;
 use crate::get_config;
-use crate::store::TransactInstruction::Set;
-use crate::store::{Store, Transaction};
+use crate::store::{Store, TransactInstruction, Transaction};
 use std::fs::File;
 use std::io::BufReader;
 use std::path::Path;
@@ -222,7 +221,10 @@ impl<S: Store + Send + Sync + Clone + 'static> Connection<S> {
                 tracing::info!("SET {key:?}");
                 tracing::trace!("SET {key:?} {val:?}");
                 self.store
-                    .transact(Transaction::with_random_id(vec![Set(key, &val)]))
+                    .transact(Transaction::with_random_id(vec![TransactInstruction::set(
+                        key,
+                        val.as_slice(),
+                    )]))
                     .await
                     .ok();
                 let len_v = val.len().to_string();

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,6 +1,6 @@
 use crate::error::Result;
 use crate::get_config;
-use crate::store::{Store, TransactInstruction, Transaction};
+use crate::store::{Operation, Store, Transaction};
 use std::fs::File;
 use std::io::BufReader;
 use std::path::Path;
@@ -221,7 +221,7 @@ impl<S: Store + Send + Sync + Clone + 'static> Connection<S> {
                 tracing::info!("SET {key:?}");
                 tracing::trace!("SET {key:?} {val:?}");
                 self.store
-                    .transact(Transaction::with_random_id(vec![TransactInstruction::set(
+                    .transact(Transaction::with_random_id(vec![Operation::set(
                         key,
                         val.as_slice(),
                     )]))

--- a/src/store/lsm.rs
+++ b/src/store/lsm.rs
@@ -10,7 +10,7 @@ use tokio::sync::Mutex;
 
 use self::commit_log::CommitLog;
 
-use super::TransactInstruction::{Delete, Set};
+use super::Operation::{Delete, Set};
 use super::{Store, Transaction};
 use crate::Result;
 
@@ -57,7 +57,7 @@ impl Store for LSMStore {
     async fn transact(&mut self, transaction: Transaction) -> Result<()> {
         self.commit_log.begin_transaction(&transaction).await?;
         let mut store = self.data.lock().await;
-        for instruction in transaction.instructions {
+        for instruction in transaction.operations {
             match instruction {
                 Set(key, value) => {
                     store.memtable.insert(key.to_string(), Some(value.to_vec()));

--- a/src/store/lsm.rs
+++ b/src/store/lsm.rs
@@ -26,8 +26,8 @@ struct LSMStoreData {
 }
 
 impl LSMStore {
-    pub async fn new(commit_log_path: &Path) -> Result<Self> {
-        let commit_log = CommitLog::new(commit_log_path).await?;
+    pub async fn initialize(commit_log_path: &Path) -> Result<Self> {
+        let commit_log = CommitLog::initialize(commit_log_path).await?;
         Ok(Self {
             commit_log,
             data: Arc::new(Mutex::new(LSMStoreData {

--- a/src/store/lsm/commit_log.rs
+++ b/src/store/lsm/commit_log.rs
@@ -73,10 +73,12 @@ impl CommitLog {
         })
     }
 
+    /// Returns the shared open file handle
     fn get_write_handle(&mut self) -> &mut File {
         &mut self.logfile
     }
 
+    /// Returns a new owned file handle
     async fn get_read_handle(&self) -> Result<File> {
         let file = OpenOptions::new()
             .read(true)
@@ -115,8 +117,6 @@ impl CommitLog {
     /// Should only be called on startup before the node starts receiving traffic.
     pub async fn get_unfinished_transactions(&mut self) -> Result<Vec<Transaction>> {
         let mut txs = HashMap::new();
-        // Get an owned version of the file
-        // This is safe since this method is only called before any writes are done
         let logfile = self.get_read_handle().await?;
         let mut i = 0;
         let mut reader = BufReader::new(logfile);

--- a/src/store/lsm/commit_log.rs
+++ b/src/store/lsm/commit_log.rs
@@ -1,0 +1,73 @@
+//! The commit log is a file-backed append-only log of transactions performed by the KV store.
+//! It's used to recover unfinished transactions in the event of an unplanned shutdown.
+
+use std::path::Path;
+
+use rmp_serde::{Deserializer, Serializer};
+use serde::{Deserialize, Serialize};
+use tokio::{
+    fs::{File, OpenOptions},
+    io::AsyncWriteExt,
+};
+use uuid::Uuid;
+
+use crate::{
+    store::{TransactInstruction, Transaction},
+    Error, Result,
+};
+
+pub struct CommitLog<'a> {
+    log_path: &'a Path,
+}
+
+impl<'a> CommitLog<'a> {
+    pub fn new(log_path: &'a Path) -> Self {
+        Self { log_path }
+    }
+
+    async fn get_log_file(&mut self) -> Result<File> {
+        OpenOptions::new()
+            .read(true)
+            .append(true)
+            .create(true)
+            .open(self.log_path)
+            .await?
+    }
+
+    fn encode_tx(instructions: &Vec<TransactInstruction>) -> Vec<u8> {
+        let mut buf = Vec::new();
+        instructions.serialize(&mut Serializer::new(&mut buf));
+        buf
+    }
+
+    fn decode_tx(encoded: &[u8]) -> Result<Vec<TransactInstruction>> {
+        let mut de = Deserializer::new(encoded);
+        match Deserialize::deserialize(&mut de) {
+            Ok(res) => Ok(res),
+            Err(e) => Err(Error::MsgPackDecode(e)),
+        }
+    }
+
+    /// Writes a begin_transaction line to the commit log.
+    pub async fn begin_transaction<'b>(&mut self, tx: Transaction<'b>) -> Result<()> {
+        let mut bytes = b"begin_transaction:".to_vec();
+        bytes.append(&mut tx.id.as_bytes().to_vec());
+        bytes.append(&mut Self::encode_tx(&tx.instructions));
+        let mut logfile = self.get_log_file().await?;
+        logfile.write_all(&bytes).await?;
+        // TODO this is expensive. Should we relax the durability guarantee a bit,
+        // say by syncing the logfile every n seconds or something?
+        logfile.sync_all().await?;
+        Ok(())
+    }
+
+    /// Writes an end_transaction line to the commit log.
+    pub async fn end_transaction(&self, tx_id: Uuid) -> Result<()> {}
+
+    /// Returns any unfinished transactions found in the commit log.
+    /// Should only be called on startup before the node starts receiving traffic.
+    pub async fn get_unfinished_transaction<'b, K: AsRef<str> + Send>(
+        &self,
+    ) -> Vec<Transaction<'b>> {
+    }
+}

--- a/src/store/lsm/commit_log.rs
+++ b/src/store/lsm/commit_log.rs
@@ -92,6 +92,8 @@ impl<'a> CommitLog<'a> {
         let logfile = self.get_log_file().await?;
         let mut i = 0;
         let mut reader = BufReader::new(logfile);
+        // TODO this is swallowing errors, we need proper error handling that ignores
+        // UnexpectedEof but handles everything else
         while let Ok(line) = CommitLogLine::decode_from(&mut reader).await {
             match line {
                 BeginTx(tx) => {
@@ -114,10 +116,7 @@ impl<'a> CommitLog<'a> {
 #[cfg(test)]
 mod tests {
     use crate::{
-        store::{
-            TransactInstruction::{self, Set},
-            Transaction,
-        },
+        store::{TransactInstruction, Transaction},
         Error, Result,
     };
     use std::{

--- a/src/store/lsm/commit_log.rs
+++ b/src/store/lsm/commit_log.rs
@@ -158,4 +158,14 @@ mod tests {
         assert_eq!(vec![tx2.clone()], unfinished_txs);
         Ok(())
     }
+
+    #[tokio::test]
+    async fn test_empty_log() -> Result<()> {
+        let path = self::get_tmp_log_path()?;
+        let mut commit_log = CommitLog::new(path.as_path());
+        let unfinished_txs = commit_log.get_unfinished_transactions().await?;
+        let empty: Vec<Transaction> = vec![];
+        assert_eq!(empty, unfinished_txs);
+        Ok(())
+    }
 }

--- a/src/store/lsm/commit_log.rs
+++ b/src/store/lsm/commit_log.rs
@@ -140,29 +140,19 @@ impl CommitLog {
 
 #[cfg(test)]
 mod tests {
+    use uuid::Uuid;
+
     use crate::{
         store::{TransactInstruction, Transaction},
-        Error, Result,
+        Result,
     };
-    use std::{
-        env,
-        time::{SystemTime, UNIX_EPOCH},
-    };
+    use std::env;
 
     use super::CommitLog;
 
     async fn get_commit_log() -> Result<CommitLog> {
-        let path = match SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map(|d| env::temp_dir().join(format!("commit_log_{}", d.as_millis())))
-        {
-            Ok(p) => Ok(p),
-            Err(e) => Err(Error::SystemTimeError(e)),
-        };
-        match path {
-            Ok(p) => CommitLog::new(p.as_path()).await,
-            Err(e) => Err(e),
-        }
+        let path = env::temp_dir().join(format!("commit_log_{}", Uuid::new_v4()));
+        CommitLog::new(path.as_path()).await
     }
 
     #[tokio::test]

--- a/src/store/lsm/commit_log.rs
+++ b/src/store/lsm/commit_log.rs
@@ -129,7 +129,6 @@ mod tests {
 
     fn get_tmp_log_path() -> Result<PathBuf> {
         let path = env::temp_dir();
-        println!("path: {:?}", path);
         match SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .map(|d| path.join(format!("commit_log_{}", d.as_millis())))

--- a/src/store/lsm/commit_log.rs
+++ b/src/store/lsm/commit_log.rs
@@ -152,7 +152,7 @@ mod tests {
     use uuid::Uuid;
 
     use crate::{
-        store::{TransactInstruction, Transaction},
+        store::{Operation, Transaction},
         Result,
     };
     use std::env;
@@ -167,9 +167,9 @@ mod tests {
     #[tokio::test]
     async fn test_end_to_end() -> Result<()> {
         let mut commit_log = self::get_commit_log().await?;
-        let tx1 = Transaction::with_random_id(vec![TransactInstruction::set("foo", b"bar")]);
-        let tx2 = Transaction::with_random_id(vec![TransactInstruction::set("foo", b"bar")]);
-        let tx3 = Transaction::with_random_id(vec![TransactInstruction::set("foo", b"bar")]);
+        let tx1 = Transaction::with_random_id(vec![Operation::set("foo", b"bar")]);
+        let tx2 = Transaction::with_random_id(vec![Operation::set("foo", b"bar")]);
+        let tx3 = Transaction::with_random_id(vec![Operation::set("foo", b"bar")]);
         commit_log.begin_transaction(&tx1).await?;
         commit_log.begin_transaction(&tx2).await?;
         commit_log.begin_transaction(&tx3).await?;

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -16,9 +16,11 @@ pub enum TransactInstruction<'a>
     Delete(&'a str),
 }
 
+#[derive(Deserialize, Serialize)]
 pub struct Transaction<'a>
 {
     id: Uuid,
+    #[serde(borrow)]
     instructions: Vec<TransactInstruction<'a>>,
 }
 


### PR DESCRIPTION
This adds a `CommitLog` struct that provides an API to interact with the commit log. As part of this I made the `Transaction` struct own all of its data to make it easier to serialize; this adds some extra copying to the write path but makes things way easier to deal with.