### PR TITLE
Optimize SSTable file format to not load full table into memory on reads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -397,6 +397,7 @@ dependencies = [
  "async-trait",
  "base64",
  "bincode",
+ "bytes",
  "cached",
  "chrono",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -405,6 +405,7 @@ dependencies = [
  "growable-bloom-filter",
  "itertools",
  "lazy_static",
+ "maplit",
  "parking_lot",
  "ring",
  "rustls-pemfile",
@@ -448,6 +449,12 @@ checksum = "6389c490849ff5bc16be905ae24bc913a9c8892e19b2341dbc175e14c341c2b8"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "matchers"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,3 +65,6 @@ bincode = "1.3.3"
 # utilties for iterables
 # https://docs.rs/itertools/0.10.3
 itertools = "0.10.3"
+# byte array wrapper types
+# https://docs.rs/bytes/1.1.0
+bytes = "1.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,3 +68,8 @@ itertools = "0.10.3"
 # byte array wrapper types
 # https://docs.rs/bytes/1.1.0
 bytes = "1.1.0"
+
+[dev-dependencies]
+# map literal macros
+# https://docs.rs/maplit/latest/maplit/
+maplit = "1.0.2"

--- a/src/store/lsm.rs
+++ b/src/store/lsm.rs
@@ -48,7 +48,7 @@ struct LSMData {
     tx_ids: Vec<Uuid>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub enum Value {
     Data(Vec<u8>),
     Tombstone,

--- a/src/store/lsm.rs
+++ b/src/store/lsm.rs
@@ -482,6 +482,8 @@ mod tests {
             b"bar".to_vec(),
             store.get("foo").await?.expect("Could not find key")
         );
+        let reconstructed_bloom = store.reconstruct_bloom_map_from_sstables().await?;
+        assert_eq!(1, reconstructed_bloom.len());
         Ok(())
     }
 

--- a/src/store/lsm/sstable.rs
+++ b/src/store/lsm/sstable.rs
@@ -71,7 +71,7 @@ impl SSTable {
         for (key, val) in memtable.iter() {
             let size = bincode::serialized_size(val)?;
             index.insert(key.clone(), IndexEntry { offset, size });
-            offset += size + 1;
+            offset += size;
         }
         let index_size = bincode::serialized_size(&index)?;
         for (_, val) in index.iter_mut() {

--- a/src/store/lsm/sstable.rs
+++ b/src/store/lsm/sstable.rs
@@ -1,24 +1,36 @@
 //! Sorted-string table data file format
+//!
+//! # File Format
+//! The files consist of:
+//!   1. A u64 representing the size of the index block
+//!   2. The index block, which is a bincode-serialized BTreeMap<String, IndexEntry>
+//!   3. The data block, consisting of concatenated bincode-serialized Value objects
+//!
+//! To find a value, the index is loaded into memory, then searched to
+//! yield the offset and size of the Value associated with the
+//! searched-for key.
 
-use std::{collections::BTreeMap, path::PathBuf};
+use std::{collections::BTreeMap, io::SeekFrom, mem, path::PathBuf};
 
 use crate::{Error, Result};
-use itertools::Itertools;
+use bytes::BytesMut;
+use serde::{Deserialize, Serialize};
 use tokio::{
     fs::{self, File, OpenOptions},
-    io::{AsyncReadExt, AsyncWriteExt},
+    io::{AsyncRead, AsyncReadExt, AsyncSeek, AsyncSeekExt, AsyncWriteExt},
 };
 
 use super::Value;
 
-// TODO this implementation loads the entire sstable into memory to
-// search for a value.  A better approach would be serialize the
-// sstable into an index block and a data block.  The data block is
-// all of the values from the memtable serialized and concatenated.
-// The index block is a serialized HashMap<String, u64> that maps keys
-// to offsets into the data block.  This approach means we just need
-// to load the keys into memory to search the stream instead of the
-// values as well.
+type Index = BTreeMap<String, IndexEntry>;
+
+#[derive(Debug, Serialize, Deserialize)]
+struct IndexEntry {
+    // Byte offset from the beginning of the SSTable file where the value is stored
+    offset: u64,
+    // Size in bytes of the value block
+    size: u64,
+}
 
 #[derive(Debug)]
 pub struct SSTable {
@@ -54,20 +66,60 @@ impl SSTable {
             ))),
             Err(_) => Ok(()),
         }?;
+        let mut offset = 0;
+        let mut index = BTreeMap::new();
+        for (key, val) in memtable.iter() {
+            let size = bincode::serialized_size(val)?;
+            index.insert(key.clone(), IndexEntry { offset, size });
+            offset += size + 1;
+        }
+        let index_size = bincode::serialized_size(&index)?;
+        for (_, val) in index.iter_mut() {
+            val.offset += mem::size_of::<u64>() as u64 + index_size;
+        }
+        let buf = bincode::serialize(&index)?;
         let mut file = self.file_handle().await?;
-        let buf = &mut bincode::serialize(memtable)?;
+        file.write_u64(index_size).await?;
         file.write_all(buf.as_slice()).await?;
+        for val in memtable.values() {
+            file.write_all(bincode::serialize(val)?.as_slice()).await?;
+        }
         file.sync_all().await?;
         Ok(())
+    }
+
+    async fn read_index<R: AsyncRead + Unpin>(&self, reader: &mut R) -> Result<Index> {
+        let index_size = reader.read_u64().await?;
+        let mut buf = BytesMut::with_capacity(self::u64_to_usize(index_size));
+        reader.read_buf(&mut buf).await?;
+        let index = bincode::deserialize(buf.as_ref())?;
+        Ok(index)
+    }
+
+    async fn read_value<R: AsyncRead + AsyncSeek + Unpin>(
+        &self,
+        reader: &mut R,
+        index_entry: &IndexEntry,
+    ) -> Result<Value> {
+        let IndexEntry { offset, size } = index_entry;
+        let mut buf = BytesMut::with_capacity(self::u64_to_usize(*size));
+        reader.seek(SeekFrom::Start(*offset)).await?;
+        reader.read_buf(&mut buf).await?;
+        let val = bincode::deserialize(buf.as_ref())?;
+        Ok(val)
     }
 
     /// Returns the value associated with the key if it exists in the SSTable.
     pub async fn search(&self, key: String) -> Result<Option<Value>> {
         let mut file = self.file_handle().await?;
-        let mut buf = Vec::new();
-        file.read_to_end(&mut buf).await?;
-        let memtable: BTreeMap<String, Value> = bincode::deserialize(buf.as_slice())?;
-        Ok(memtable.get(&key).map(|v| v.to_owned()))
+        let index = self.read_index(&mut file).await?;
+        match index.get(&key) {
+            Some(index_entry) => self
+                .read_value(&mut file, index_entry)
+                .await
+                .map(Option::Some),
+            None => Ok(None),
+        }
     }
 
     pub async fn scan(
@@ -76,21 +128,27 @@ impl SSTable {
         to_exclusive: &str,
     ) -> Result<Vec<(String, Value)>> {
         let mut file = self.file_handle().await?;
-        let mut buf = Vec::new();
-        file.read_to_end(&mut buf).await?;
-        let memtable: BTreeMap<String, Value> = bincode::deserialize(buf.as_slice())?;
-        Ok(memtable
-            .range(from_inclusive.to_string()..to_exclusive.to_string())
-            .into_iter()
-            .map(|(k, v)| (k.to_owned(), v.to_owned()))
-            .collect_vec())
+        let index = self.read_index(&mut file).await?;
+        let mut result = Vec::new();
+        for (key, index_entry) in index.range(from_inclusive.to_string()..to_exclusive.to_string())
+        {
+            let val = self.read_value(&mut file, index_entry).await?;
+            result.push((key.clone(), val));
+        }
+        Ok(result)
     }
 
     pub async fn keys(&self) -> Result<Vec<String>> {
         let mut file = self.file_handle().await?;
-        let mut buf = Vec::new();
-        file.read_to_end(&mut buf).await?;
-        let memtable: BTreeMap<String, Value> = bincode::deserialize(buf.as_slice())?;
-        Ok(memtable.keys().map(|k| k.to_string()).collect())
+        let index = self.read_index(&mut file).await?;
+        Ok(index.into_keys().collect())
     }
+}
+
+fn u64_to_usize(input: u64) -> usize {
+    // Annoyingly, bincode::deserialized_size returns a u64 but
+    // BytesMut::with_capacity expects a usize. This is a bad way to
+    // solve that problem so hopefully we'll come up with something
+    // better at some point
+    usize::try_from(input).expect("32 bit architecture not supported")
 }


### PR DESCRIPTION
The new structure uses an index block mapping keys to the byte offset + 
size of the associated key in the data block of the file. This means
that only the index block needs to be loaded into memory to search/scan.